### PR TITLE
fix: Render CORS for unredacted.vercel.app

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -16,5 +16,5 @@ COPY . /app/agents/
 
 EXPOSE 8000
 
-# Railway injects $PORT; default to 8000 for local docker run
+# Render injects $PORT; default to 8000 for local docker run
 CMD uvicorn agents.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/render.yaml
+++ b/render.yaml
@@ -22,4 +22,4 @@ services:
       - key: FEC_API_KEY
         sync: false
       - key: CORS_ORIGINS
-        sync: false
+        value: https://unredacted.vercel.app


### PR DESCRIPTION
- Set `CORS_ORIGINS` default in render.yaml to `https://unredacted.vercel.app`
- Fix Dockerfile comment: Railway → Render