### PR TITLE
fix: bump langchain-core to 0.3.30

### DIFF
--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -7,7 +7,7 @@ uvicorn[standard]==0.34.0
 
 # LangChain + LangGraph AI stack
 langchain==0.3.14
-langchain-core==0.3.29
+langchain-core==0.3.30
 langgraph==0.2.62
 
 # Provider SDKs — install all so AI_PROVIDER can be switched via env var


### PR DESCRIPTION
langchain-anthropic==0.3.3 requires >=0.3.30; was pinned at 0.3.29 causing Docker build failure.