### PR TITLE
fix: drop langchain-core pin to fix Docker build

### DIFF
--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -7,7 +7,6 @@ uvicorn[standard]==0.34.0
 
 # LangChain + LangGraph AI stack
 langchain==0.3.14
-langchain-core==0.3.30
 langgraph==0.2.62
 
 # Provider SDKs — install all so AI_PROVIDER can be switched via env var


### PR DESCRIPTION
Removes explicit langchain-core pin that caused irresolvable conflicts between langchain-anthropic (>=0.3.30) and langchain-openai (>=0.3.34).