### PR TITLE
fix: revert langgraph to 0.2.62

### DIFF
--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -7,7 +7,7 @@ uvicorn[standard]==0.34.0
 
 # LangChain + LangGraph AI stack
 langchain==0.3.14
-langgraph==1.0.10rc1
+langgraph==0.2.62
 
 # Provider SDKs — install all so AI_PROVIDER can be switched via env var
 langchain-anthropic==0.3.3      # AI_PROVIDER=anthropic (default)


### PR DESCRIPTION
langgraph 1.x requires langchain-core>=1.0.0 via langgraph-prebuilt, incompatible with entire langchain 0.3.x stack.