### PR TITLE
fix: remove hardcoded deepseek-chat model in Node.js agents

### DIFF
--- a/server/agents/corruptionAgent.js
+++ b/server/agents/corruptionAgent.js
@@ -9,7 +9,6 @@ export async function runCorruptionAgent({ plan, policyResults, spendingResults,
   const context = `POLICY DATA (Federal Register):\n${policyCtx}\n\nSPENDING DATA (USASpending.gov):\n${spendingCtx}\n\nCAMPAIGN FINANCE DATA (FEC):\n${donorCtx}`
 
   const response = await createChatCompletion({
-    model: process.env.AI_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'deepseek-chat',
     response_format: { type: 'json_object' },
     max_tokens: 1500,
     messages: [

--- a/server/agents/orchestrator.js
+++ b/server/agents/orchestrator.js
@@ -7,7 +7,6 @@ import { runDonorAgent } from './donorAgent.js'
 export async function orchestrate(userQuery) {
   // Step 1: Decompose the query using DeepSeek (default)
   const decomposition = await createChatCompletion({
-    model: process.env.AI_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'deepseek-chat',
     response_format: { type: 'json_object' },
     max_tokens: 500,
     messages: [


### PR DESCRIPTION
orchestrator.js and corruptionAgent.js forced model='deepseek-chat' for non-groq providers. When AI_PROVIDER=anthropic this causes a 404. aiService.js DEFAULT_MODELS already maps anthropic→claude-3-5-sonnet, so removing the override fixes it.