### PR TITLE
revert: restore deepseek model, fix via Vercel AI_PROVIDER=deepseek

### DIFF
--- a/server/agents/corruptionAgent.js
+++ b/server/agents/corruptionAgent.js
@@ -9,6 +9,7 @@ export async function runCorruptionAgent({ plan, policyResults, spendingResults,
   const context = `POLICY DATA (Federal Register):\n${policyCtx}\n\nSPENDING DATA (USASpending.gov):\n${spendingCtx}\n\nCAMPAIGN FINANCE DATA (FEC):\n${donorCtx}`
 
   const response = await createChatCompletion({
+    model: process.env.AI_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'deepseek-chat',
     response_format: { type: 'json_object' },
     max_tokens: 1500,
     messages: [

--- a/server/agents/orchestrator.js
+++ b/server/agents/orchestrator.js
@@ -7,6 +7,7 @@ import { runDonorAgent } from './donorAgent.js'
 export async function orchestrate(userQuery) {
   // Step 1: Decompose the query using DeepSeek (default)
   const decomposition = await createChatCompletion({
+    model: process.env.AI_PROVIDER === 'groq' ? 'llama-3.3-70b-versatile' : 'deepseek-chat',
     response_format: { type: 'json_object' },
     max_tokens: 500,
     messages: [


### PR DESCRIPTION
Node agents use DeepSeek by design. Fixed by setting AI_PROVIDER=deepseek + DEEPSEEK_API_KEY in Vercel env vars instead of changing agent code.