### PR TITLE
feat: add Vercel Analytics with custom event tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.99.1",
         "@upstash/redis": "^1.36.1",
+        "@vercel/analytics": "^2.0.1",
         "axios": "^1.13.6",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
@@ -1737,6 +1738,48 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.99.1",
     "@upstash/redis": "^1.36.1",
+    "@vercel/analytics": "^2.0.1",
     "axios": "^1.13.6",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, createContext, useContext } from "react";
+import { track } from "@vercel/analytics";
 import Settings from "./components/Settings.jsx";
 import DarkMoneyTracker from "./components/DarkMoneyTracker.jsx";
 import CompanyProfile from "./components/CompanyProfile.jsx";
@@ -546,6 +547,7 @@ function PolicyIntel() {
   const send = async () => {
     if (!input.trim()) return;
     const q = input; setInput(""); setThinking(true);
+    track("analyst_query", { panel: "policy", query_length: q.length });
     setMsgs(m => [...m, { role:"user", text:q }]);
     try {
       const res = await queryAgent(q);
@@ -1115,6 +1117,7 @@ function AnalystPanel({ onClose, dark }) {
     const q = (text || input).trim();
     if (!q || loading) return;
     setInput("");
+    track("analyst_query", { panel: "main", query_length: q.length });
     setMsgs(m => [...m, { role:"user", content:q }]);
     setLoading(true);
     setRouting(null);
@@ -1565,7 +1568,7 @@ function AppInner() {
           {TABS.map(tb => {
             const on = tab===tb.id;
             return (
-              <button key={tb.id} onClick={() => setTab(tb.id)} style={{
+              <button key={tb.id} onClick={() => { setTab(tb.id); track("tab_view", { tab: tb.id }); }} style={{
                 background:"transparent",
                 color: on ? ORANGE : theme.mid,
                 border:"none",
@@ -1585,7 +1588,7 @@ function AppInner() {
           <div style={{ marginLeft:"auto", display:"flex", alignItems:"center", gap:9 }}>
             <div style={{ fontFamily:MF, fontSize:8.5, color:theme.low, border:`1px solid ${theme.border}`, padding:"4px 10px" }}>🔔 12</div>
 
-            <button onClick={() => setDark(d => !d)} style={{
+            <button onClick={() => { const next = !dark; setDark(next); track("theme_toggle", { theme: next ? "dark" : "light" }); }} style={{
               display:"flex", alignItems:"center", gap:6,
               background:theme.cardB, border:`1px solid ${theme.border}`, borderRadius:20,
               padding:"5px 11px", fontFamily:MF, fontSize:9, color:theme.mid, transition:"all .2s",
@@ -1598,7 +1601,7 @@ function AppInner() {
             {isAuthenticated ? (
               <div style={{ display:"flex", alignItems:"center", gap:6 }}>
                 <button
-                  onClick={() => setTab("watchlist")}
+                  onClick={() => { setTab("watchlist"); track("tab_view", { tab: "watchlist" }); }}
                   title={`Signed in as ${profile?.display_name || user?.email}`}
                   style={{
                     display:"flex", alignItems:"center", gap:6,
@@ -1613,7 +1616,7 @@ function AppInner() {
                   </span>
                 </button>
                 <button
-                  onClick={() => signOut()}
+                  onClick={() => { track("auth_sign_out"); signOut(); }}
                   title="Sign out"
                   style={{
                     background:"none", border:`1px solid ${theme.border}`,
@@ -1626,7 +1629,7 @@ function AppInner() {
               </div>
             ) : (
               <button
-                onClick={() => setShowAuth(true)}
+                onClick={() => { track("auth_sign_in_click"); setShowAuth(true); }}
                 style={{
                   display:"flex", alignItems:"center", gap:6,
                   background:theme.cardB, border:`1px solid ${theme.border}`,
@@ -1641,7 +1644,7 @@ function AppInner() {
 
             {/* ANALYST BUTTON */}
             <button
-              onClick={() => setAnalyst(a => !a)}
+              onClick={() => { const next = !analyst; setAnalyst(next); track("analyst_panel_toggle", { open: next }); }}
               style={{
                 display:"flex", alignItems:"center", gap:7,
                 background: analyst ? ORANGE : ORANGE+"18",
@@ -1660,7 +1663,7 @@ function AppInner() {
             {/* SETTINGS BUTTON — far right */}
             <div style={{ width:1, height:22, background:theme.border, flexShrink:0 }}/>
             <button
-              onClick={() => setTab(t => t==="settings" ? "overview" : "settings")}
+              onClick={() => { setTab(t => { const next = t === "settings" ? "overview" : "settings"; track("tab_view", { tab: next }); return next; }); }}
               style={{
                 display:"flex", alignItems:"center", gap:6,
                 background:"transparent", border:"none",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { Analytics } from '@vercel/analytics/react'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
+    <Analytics />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Install `@vercel/analytics` and mount `<Analytics />` in `main.jsx` for automatic page view tracking
- Add `track()` calls for 6 key user interaction events across `App.jsx`

## Events tracked

| Event | Trigger |
|---|---|
| `tab_view` | Any tab click (overview, donors, policy, spending, companies, corruption, watchlist, settings) |
| `theme_toggle` | Dark/light mode switch — includes `{ theme }` property |
| `analyst_panel_toggle` | Analyst ◈ button — includes `{ open }` property |
| `analyst_query` | Query submitted in either analyst panel — includes `{ panel, query_length }` |
| `auth_sign_in_click` | "SIGN IN" button clicked |
| `auth_sign_out` | Sign out button clicked |

## Notes
- Uses `@vercel/analytics/react` (not `/next`) — this is a React 19 + Vite app, not Next.js
- Analytics is a no-op in dev; activates automatically once deployed to Vercel
- Build verified clean: `✓ built in 891ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)